### PR TITLE
inaccurate calculation of first_token's pos_emb

### DIFF
--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -439,7 +439,7 @@ def get_timing_signal_1d(length,
   Returns:
     a Tensor of timing signals [1, length, channels]
   """
-  position = tf.to_float(tf.range(length) + start_index)
+  position = tf.to_float(tf.range(1, 1+length) + start_index)
   num_timescales = channels // 2
   log_timescale_increment = (
       math.log(float(max_timescale) / float(min_timescale)) /


### PR DESCRIPTION
since,
1. scaled_time is calculated by `scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)`, while position_idx in position will **start by 0**.
2. scaled_time will be used to calculate position embedding by `signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)`

Thus, position_embedding of first token will always be combined with half zeros and half ones.

But the purpose of addding timing pos_embed should be helping model to learn relative and absolute position information between words by triangle relations of these words, i.e. sin(\alpha+\beta)=sin(\alpha)cos(\beta)+sin(\beta)cos(\alpha).